### PR TITLE
ci: add dco workaround

### DIFF
--- a/.github/workflows/dco-merge-group.yaml
+++ b/.github/workflows/dco-merge-group.yaml
@@ -1,0 +1,15 @@
+# based on https://github.com/onnx/onnx/blob/main/.github/workflows/dco_merge_group.yml
+
+name: DCO
+on:
+  merge_group:
+
+permissions:  # set top-level default permissions as security best practice
+  contents: read # Check https://github.com/ossf/scorecard/blob/7ce8609469289d5f3b1bf5ee3122f42b4e3054fb/docs/checks.md#token-permissions
+
+jobs:
+  DCO:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - run: echo "dummy DCO workflow (it won't run any check actually) to trigger by merge_group in order to enable merge queue"


### PR DESCRIPTION
## This PR

- adds a DCO ci workaround

### Notes

Workaround that allows us to use GitHub merge queues with the DCO app.