### PR TITLE
docs: Add initial flag manifest schema

### DIFF
--- a/docs/schema/v0/flag_manifest.json
+++ b/docs/schema/v0/flag_manifest.json
@@ -1,0 +1,122 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+        "flag": {
+            "oneOf": [
+                {
+                    "$ref": "#/$defs/boolType"
+                },
+                {
+                    "$ref": "#/$defs/stringType"
+                },
+                {
+                    "$ref": "#/$defs/intType"
+                },
+                {
+                    "$ref": "#/$defs/floatType"
+                },
+                {
+                    "$ref": "#/$defs/objectType"
+                }
+            ],
+            "required": ["flag_type", "default_value"]
+        },
+        "boolType": {
+            "type": "object",
+            "properties": {
+                "flag_type": {
+                    "type": "string",
+                    "enum": ["bool"]
+                },
+                "default_value": {
+                    "type": "boolean" 
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "stringType": {
+            "type": "object",
+            "properties": {
+                "flag_type": {
+                    "type": "string",
+                    "enum": ["string"]
+                },
+                "default_value": {
+                    "type": "string" 
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "intType": {
+            "type": "object",
+            "properties": {
+                "flag_type": {
+                    "type": "string",
+                    "enum": ["int"]
+                },
+                "default_value": {
+                    "type": "integer" 
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "floatType": {
+            "type": "object",
+            "properties": {
+                "flag_type": {
+                    "type": "string",
+                    "enum": ["float"]
+                },
+                "default_value": {
+                    "type": "number" 
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "objectType": {
+            "type": "object",
+            "properties": {
+                "flag_type": {
+                    "type": "string",
+                    "enum": ["object"]
+                },
+                "default_value": {
+                    "type": "object" 
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        }    
+    },
+    "title": "Flag Manifest",
+    "description": "Manifest meant to describe the flags of one flag configuration",
+    "type": "object",
+    "properties": {
+        "flags": {
+            "description": "Object containing the flags in the config",
+            "type": "object",
+            "patternProperties": {
+                "^.{1,}$": {
+                    "description": "The definition of one flag",
+                    "$ref": "#/$defs/flag"
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "required": ["flags"]
+}

--- a/docs/schema/v0/flag_manifest.json
+++ b/docs/schema/v0/flag_manifest.json
@@ -4,16 +4,16 @@
         "flag": {
             "oneOf": [
                 {
-                    "$ref": "#/$defs/boolType"
+                    "$ref": "#/$defs/booleanType"
                 },
                 {
                     "$ref": "#/$defs/stringType"
                 },
                 {
-                    "$ref": "#/$defs/intType"
+                    "$ref": "#/$defs/integerType"
                 },
                 {
-                    "$ref": "#/$defs/floatType"
+                    "$ref": "#/$defs/numberType"
                 },
                 {
                     "$ref": "#/$defs/objectType"
@@ -21,12 +21,12 @@
             ],
             "required": ["flag_type", "default_value"]
         },
-        "boolType": {
+        "booleanType": {
             "type": "object",
             "properties": {
                 "flag_type": {
                     "type": "string",
-                    "enum": ["bool"]
+                    "enum": ["boolean"]
                 },
                 "default_value": {
                     "type": "boolean" 
@@ -53,12 +53,12 @@
             },
             "additionalProperties": false
         },
-        "intType": {
+        "integerType": {
             "type": "object",
             "properties": {
                 "flag_type": {
                     "type": "string",
-                    "enum": ["int"]
+                    "enum": ["integer"]
                 },
                 "default_value": {
                     "type": "integer" 
@@ -69,12 +69,12 @@
             },
             "additionalProperties": false
         },
-        "floatType": {
+        "numberType": {
             "type": "object",
             "properties": {
                 "flag_type": {
                     "type": "string",
-                    "enum": ["float"]
+                    "enum": ["number"]
                 },
                 "default_value": {
                     "type": "number" 

--- a/docs/schema/v0/flag_manifest.json
+++ b/docs/schema/v0/flag_manifest.json
@@ -1,5 +1,22 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Flag Manifest",
+    "description": "Describes a configuration of OpenFeature flags, including info such as their types and default values.",
+    "type": "object",
+    "properties": {
+        "flags": {
+            "description": "Object containing the flags in the config",
+            "type": "object",
+            "patternProperties": {
+                "^.{1,}$": {
+                    "description": "The definition of one flag",
+                    "$ref": "#/$defs/flag"
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "required": ["flags"],
     "$defs": {
         "flag": {
             "oneOf": [
@@ -101,22 +118,5 @@
             },
             "additionalProperties": false
         }    
-    },
-    "title": "Flag Manifest",
-    "description": "Manifest meant to describe the flags of one flag configuration",
-    "type": "object",
-    "properties": {
-        "flags": {
-            "description": "Object containing the flags in the config",
-            "type": "object",
-            "patternProperties": {
-                "^.{1,}$": {
-                    "description": "The definition of one flag",
-                    "$ref": "#/$defs/flag"
-                }
-            },
-            "additionalProperties": false
-        }
-    },
-    "required": ["flags"]
+    }
 }


### PR DESCRIPTION
## This PR
Defines a new format for a flag manifest input to the codegen tool, as defined in a JSON schema

### Related Issues

Fixes https://github.com/open-feature/codegen/issues/1

### Notes
Is based on https://docs.google.com/document/d/19GQpSNcLnDEbzJRL6FpzKHFEQWVGNrgNK25lC4-JuE8/edit#heading=h.f1glu5dk43k9



